### PR TITLE
CLI tool  to convert geometry files to usd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
-# usd_indie_pipe
-USD Indie Pipe is a lightweight USD pipeline setup made for freelancers and small teams who want to bring structure to their workflow. It’s basically a plug-and-play starter kit with clean practices, modular tools, and just enough flexibility to grow with your projects.
+# USD Indie Pipeline:
+USD Indie Pipeline is a pipeline setup (in development 😅) 
+The idea is to create a starter kit with clean practices, tools, and just enough flexibility to grow with your projects.
+
+
+# Houdini to USD CLI tool:
+
+Demo: https://vimeo.com/1097411468
+
+A CLI tool that converts geometry files (e.g., .bgeo.sc, .fbx) into .usd format.
+It parses textures based on a library name (currently supported: Kitbash, Megascans) or from a specified texture folder, creates MaterialX shaders populated with the corresponding textures, and automatically binds materials to USD primitives.
+
+Requirements
+
+USD must be installed in your environment.
+
+A valid Houdini license is required to run the conversion (uses hython).
+
+Usage
+
+Run the following command:
+
+hython /path/to/hython \
+    /path/to/convert_to_usd.py \
+    --asset-lib-path /path/to/your/geometry \
+    --lib-name Kitbash] \
+    --textures-folder-path /path/to/textures
+    
+
+Arguments
+- `--asset-lib-path (required): Path to the geometry file or asset directory.
+- `--lib-name (optional): Name of the texture library (e.g., Kitbash, Megascans).
+- `--textures-folder-path (optional): Path to the texture folder, if not using library name.
+If neither --lib-name nor --textures-folder-path is provided, the tool defaults to using the geometry folder as the texture source.
+
+Folder Structure Requirement
+
+If you specify a library name, ensure the folder structure matches the original layout from the corresponding marketplace (e.g., Kitbash or Megascans).
+
+
+Example usage (Kitbash):
+
+<img width="926" alt="image" src="https://github.com/user-attachments/assets/645daef6-134b-43ff-b262-5ba94e3d5bfa" />
+
+Example usage (Megascans):
+
+<img width="926" alt="image" src="https://github.com/user-attachments/assets/35909173-ec2f-415c-9f79-787611258b66" />
+
+Note: In the case of Megascans, each asset must be stored in a separate folder alongside its corresponding textures, following the folder structure shown in the image below:
+
+<img width="768" alt="image" src="https://github.com/user-attachments/assets/6950747b-8042-4af6-a051-1f8712ae8d88" />
+
+Example: Kitbash default folder structure
+
+<img width="768" alt="image" src="https://github.com/user-attachments/assets/1369e52a-7921-4e6f-a0d2-80a999bde188" />
+
+
+Example usage: Match geometry and texture folders independently of the library:
+
+<img width="926" alt="image" src="https://github.com/user-attachments/assets/2ceddd47-8d63-42ae-a063-da2b38b11567" />
+
+To properly resolve textures, their names should be similar to the names of the primitives you're binding them to.
+This method relies on clean naming and structure — so keeping things organized is key 😉
+
+
+

--- a/src/usd_indie_pipe/_houdini.py
+++ b/src/usd_indie_pipe/_houdini.py
@@ -1,0 +1,139 @@
+import json
+from collections import defaultdict
+from pathlib import Path
+
+import hou
+from pxr import Usd, UsdGeom, Gf, Kind, Sdf
+
+"""
+This module explores one possible approach to recreating a usd file based on imported geometry.
+A very low-level method.
+"""
+
+
+def export_houdini_geo_to_usd(geo_path: Path) -> Usd.Stage:
+    """
+    Recreates a usd mesh and subcomponents based on geometry data extracted from geo file.
+    Builds a usd hierarchy with a component prim and material subsets.
+    """
+    if not geo_path.exists():
+        print(f"Could not find {geo_path}")
+        return None
+
+
+    else:
+        # In this case, the geometry file name is used as the component name to build the hierarchy in usd
+        _name = geo_path.name.split(".")[0]
+        usd_file = construct_usd_file_path(geo_path)
+        print(f"BUILDING: {usd_file}")
+        usd_stage = Usd.Stage.CreateNew(usd_file)
+
+        # Component definition
+        comp_path = Sdf.Path(f"/{_name}")
+        component_prim = usd_stage.DefinePrim(comp_path, "Xform")
+        Usd.ModelAPI(component_prim).SetKind(Kind.Tokens.component)
+
+        # Xform group under the component definition
+        render_geo_path = comp_path.AppendPath("geom")
+        usd_stage.DefinePrim(render_geo_path, "Xform")
+        # TODO add "proxy", add "materials"
+
+        # Mesh definition
+        mesh_prim_path = render_geo_path.AppendPath(_name)
+        mesh = UsdGeom.Mesh.Define(usd_stage, mesh_prim_path)
+
+        # Import all geometry data
+        points, face_vertex_counts, face_vertex_indices, mat_faces, normals = get_houdini_geo_data(geo_path)
+
+        # Usd mesh recreation
+        usd_points = [Gf.Vec3f(p[0], p[1], p[2]) for p in points]
+        mesh.CreatePointsAttr(usd_points)
+        mesh.CreateFaceVertexCountsAttr(face_vertex_counts)
+        mesh.CreateFaceVertexIndicesAttr(face_vertex_indices)
+
+        if normals:
+            usd_normals = [Gf.Vec3f(n[0], n[1], n[2]) for n in normals]
+            mesh.CreateNormalsAttr(usd_normals)
+            mesh.SetNormalsInterpolation("vertex")
+
+        for mat_name, indices in mat_faces.items():
+            subset_path = mesh_prim_path.AppendPath(mat_name)
+            subset = UsdGeom.Subset.Define(usd_stage, subset_path)
+            subset.CreateElementTypeAttr("face")
+            subset.CreateIndicesAttr(indices)
+        usd_stage.GetRootLayer().Save()
+        print(f"Exported USD file {usd_file}")
+
+        return usd_stage
+
+
+def get_houdini_geo_data(geo_path: Path) -> tuple[
+    list[tuple[float, float, float]],  # points
+    list[int],  # face_vertex_counts
+    list[int],  # face_vertex_indices
+    dict[str, list[int]],  # mat_faces
+    list[tuple[float, float, float]]  # normals
+]:
+    """
+    Extracts geometry data, points position, vertex cound and face count, material data based on shopmaterialpath
+    normals data
+    """
+    # Create file node to import geometry and get access to geometry data
+    geo_node = hou.node("/obj").createNode("geo", "convert_geo")
+    file_node = geo_node.createNode("file")
+    file_node.parm("file").set(str(geo_path))
+    hou_geo = file_node.geometry()
+
+    points = [point.position() for point in hou_geo.iterPoints()]
+
+    face_vertex_counts = []
+    face_vertex_indices = []
+    normals = []
+    # Get material data to create subsets in mesh primitive based on the materials
+    mat_faces = defaultdict(list)
+
+    for face_index, prim in enumerate(hou_geo.iterPrims()):
+        verts = prim.vertices()
+        face_vertex_counts.append(len(verts))
+        face_vertex_indices.extend([v.point().number() for v in verts])
+
+        mat = prim.attribValue("shop_materialpath") or "default"
+        mat_name = Path(mat).name
+        mat_faces[mat_name].append(face_index)
+
+    if hou_geo.findPointAttrib("N"):
+        normals = [point.attribValue("N") for point in hou_geo.iterPoints()]
+    return points, face_vertex_counts, face_vertex_indices, mat_faces, normals
+
+
+def run_geo_to_usd_conversion(conversion_data: str):
+    """
+     Runs geometry-to-usd conversion using a list of input geometry files provided in a json file.
+
+    Parameters:
+        conversion_data (str): Path to a json file containing a list of geometry file paths (e.g., .bgeo.sc, .obj).
+    """
+    with open(conversion_data, "r") as r:
+        conv_data = json.load(r)
+    for file_path in conv_data:
+        file_path = Path(file_path)
+        export_houdini_geo_to_usd(file_path)
+
+
+def construct_usd_file_path(geo_path: Path, separate_usd_folder: bool = True) -> str:
+    """
+    Construct the output .usda path from a geometry file path.
+    If separate_usd_folder is True, usd files will be put into usd subfolder.
+    """
+
+    clean_base = geo_path.name.split(".")[0]
+    usd_file_name = clean_base + ".usda"
+
+    if separate_usd_folder:
+        usd_dir = geo_path.parent / "usd"
+    else:
+        usd_dir = geo_path.parent
+
+    usd_path = usd_dir / usd_file_name
+
+    return str(usd_path)

--- a/src/usd_indie_pipe/_houdini.py
+++ b/src/usd_indie_pipe/_houdini.py
@@ -1,12 +1,7 @@
 import json
 from pathlib import Path
-
+import _usd
 import hou
-
-"""
-This module explores one possible approach to recreating a usd file based on imported geometry.
-A very low-level method.
-"""
 
 
 def create_temp_hou_stage(file_path):
@@ -51,6 +46,8 @@ def create_temp_hou_stage(file_path):
         usd_rop.parm("execute").pressButton()
         print(f"Converted USD: {str(usd_file)}")
 
+        return usd_file
+
 
 def construct_usd_file_path(geo_path: Path, separate_usd_folder: bool = True) -> str:
     """
@@ -69,15 +66,17 @@ def construct_usd_file_path(geo_path: Path, separate_usd_folder: bool = True) ->
     return str(usd_path)
 
 
-def run_geo_to_usd_conversion(conversion_data: str):
+def run_geo_to_usd_conversion(conversion_data: str, tex_folder_path: str) -> None:
     """
      Runs geometry-to-usd conversion using a list of input geometry files provided in a json file.
 
     Parameters:
         conversion_data (str): Path to a json file containing a list of geometry file paths (e.g., .bgeo.sc, .obj).
+        tex_folder_path (str): Path to a folder containing tex files.
     """
     with open(conversion_data, "r") as r:
         conv_data = json.load(r)
     for file_path in conv_data:
         file_path = Path(file_path)
-        create_temp_hou_stage(file_path)
+        usd_file = create_temp_hou_stage(file_path)
+        _usd.run_material_assignment(usd_file, tex_folder_path)

--- a/src/usd_indie_pipe/_houdini.py
+++ b/src/usd_indie_pipe/_houdini.py
@@ -1,9 +1,7 @@
 import json
-from collections import defaultdict
 from pathlib import Path
 
 import hou
-from pxr import Usd, UsdGeom, Gf, Kind, Sdf
 
 """
 This module explores one possible approach to recreating a usd file based on imported geometry.
@@ -11,99 +9,64 @@ A very low-level method.
 """
 
 
-def export_houdini_geo_to_usd(geo_path: Path) -> Usd.Stage:
+def create_temp_hou_stage(file_path):
     """
-    Recreates a usd mesh and subcomponents based on geometry data extracted from geo file.
-    Builds a usd hierarchy with a component prim and material subsets.
+    Creates a temp usd scene in memory to import a geometry file and export usd file
     """
-    if not geo_path.exists():
-        print(f"Could not find {geo_path}")
-        return None
-
-
+    asset_name = file_path.name.split(".")[0]
+    if not file_path.exists():
+        raise FileNotFoundError(f"Could not find geometry file: {file_path}")
     else:
-        # In this case, the geometry file name is used as the component name to build the hierarchy in usd
-        _name = geo_path.name.split(".")[0]
-        usd_file = construct_usd_file_path(geo_path)
-        print(f"BUILDING: {usd_file}")
-        usd_stage = Usd.Stage.CreateNew(usd_file)
+        # create Sop read
+        sop_create = hou.node("/stage").createNode("sopcreate", asset_name)
+        sop_create.parm("enable_partitionattribs").set(True)
+        sop_create.parm("partitionattribs").set("path")
 
-        # Component definition
-        comp_path = Sdf.Path(f"/{_name}")
-        component_prim = usd_stage.DefinePrim(comp_path, "Xform")
-        Usd.ModelAPI(component_prim).SetKind(Kind.Tokens.component)
+        sop_create.parm("enable_subsetgroups").set(True)
+        sop_create.parm("subsetgroups").set("m*")
 
-        # Xform group under the component definition
-        render_geo_path = comp_path.AppendPath("geom")
-        usd_stage.DefinePrim(render_geo_path, "Xform")
-        # TODO add "proxy", add "materials"
+        # create file sop
+        file_sop = hou.node(sop_create.path() + "/sopnet/create").createNode("file")
+        file_sop.parm("file").set(str(file_path))
 
-        # Mesh definition
-        mesh_prim_path = render_geo_path.AppendPath(_name)
-        mesh = UsdGeom.Mesh.Define(usd_stage, mesh_prim_path)
+        # attrib wrangle
+        wrangle_code = f's@path = "geom/{asset_name}";'
+        attrib_wrangle = file_sop.createOutputNode("attribwrangle")
+        attrib_wrangle.parm("class").set(1)
+        attrib_wrangle.parm("snippet").set(wrangle_code)
 
-        # Import all geometry data
-        points, face_vertex_counts, face_vertex_indices, mat_faces, normals = get_houdini_geo_data(geo_path)
+        # create delete sop
+        delete = attrib_wrangle.createOutputNode("attribdelete")
+        delete.parm("primdel").set("shop_materialpath")
 
-        # Usd mesh recreation
-        usd_points = [Gf.Vec3f(p[0], p[1], p[2]) for p in points]
-        mesh.CreatePointsAttr(usd_points)
-        mesh.CreateFaceVertexCountsAttr(face_vertex_counts)
-        mesh.CreateFaceVertexIndicesAttr(face_vertex_indices)
+        # create output
+        delete.createOutputNode("output")
 
-        if normals:
-            usd_normals = [Gf.Vec3f(n[0], n[1], n[2]) for n in normals]
-            mesh.CreateNormalsAttr(usd_normals)
-            mesh.SetNormalsInterpolation("vertex")
+        usd_rop = sop_create.createOutputNode("usd_rop")
 
-        for mat_name, indices in mat_faces.items():
-            subset_path = mesh_prim_path.AppendPath(mat_name)
-            subset = UsdGeom.Subset.Define(usd_stage, subset_path)
-            subset.CreateElementTypeAttr("face")
-            subset.CreateIndicesAttr(indices)
-        usd_stage.GetRootLayer().Save()
-        print(f"Exported USD file {usd_file}")
+        usd_file = construct_usd_file_path(file_path)
+        usd_rop.parm("lopoutput").set(str(usd_file))
 
-        return usd_stage
+        # Execute save usd file
+        usd_rop.parm("execute").pressButton()
+        print(f"Converted USD: {str(usd_file)}")
 
 
-def get_houdini_geo_data(geo_path: Path) -> tuple[
-    list[tuple[float, float, float]],  # points
-    list[int],  # face_vertex_counts
-    list[int],  # face_vertex_indices
-    dict[str, list[int]],  # mat_faces
-    list[tuple[float, float, float]]  # normals
-]:
+def construct_usd_file_path(geo_path: Path, separate_usd_folder: bool = True) -> str:
     """
-    Extracts geometry data, points position, vertex cound and face count, material data based on shopmaterialpath
-    normals data
+    Construct the output .usda path from a geometry file path.
+    If separate_usd_folder is True, usd files will be put into usd subfolder.
     """
-    # Create file node to import geometry and get access to geometry data
-    geo_node = hou.node("/obj").createNode("geo", "convert_geo")
-    file_node = geo_node.createNode("file")
-    file_node.parm("file").set(str(geo_path))
-    hou_geo = file_node.geometry()
+    clean_base = geo_path.name.split(".")[0]
+    usd_file_name = clean_base + ".usda"
 
-    points = [point.position() for point in hou_geo.iterPoints()]
+    if separate_usd_folder:
+        usd_dir = geo_path.parent / "usd"
+    else:
+        usd_dir = geo_path.parent
 
-    face_vertex_counts = []
-    face_vertex_indices = []
-    normals = []
-    # Get material data to create subsets in mesh primitive based on the materials
-    mat_faces = defaultdict(list)
-
-    for face_index, prim in enumerate(hou_geo.iterPrims()):
-        verts = prim.vertices()
-        face_vertex_counts.append(len(verts))
-        face_vertex_indices.extend([v.point().number() for v in verts])
-
-        mat = prim.attribValue("shop_materialpath") or "default"
-        mat_name = Path(mat).name
-        mat_faces[mat_name].append(face_index)
-
-    if hou_geo.findPointAttrib("N"):
-        normals = [point.attribValue("N") for point in hou_geo.iterPoints()]
-    return points, face_vertex_counts, face_vertex_indices, mat_faces, normals
+    usd_path = usd_dir / usd_file_name
+    return str(usd_path)
 
 
 def run_geo_to_usd_conversion(conversion_data: str):
@@ -117,23 +80,4 @@ def run_geo_to_usd_conversion(conversion_data: str):
         conv_data = json.load(r)
     for file_path in conv_data:
         file_path = Path(file_path)
-        export_houdini_geo_to_usd(file_path)
-
-
-def construct_usd_file_path(geo_path: Path, separate_usd_folder: bool = True) -> str:
-    """
-    Construct the output .usda path from a geometry file path.
-    If separate_usd_folder is True, usd files will be put into usd subfolder.
-    """
-
-    clean_base = geo_path.name.split(".")[0]
-    usd_file_name = clean_base + ".usda"
-
-    if separate_usd_folder:
-        usd_dir = geo_path.parent / "usd"
-    else:
-        usd_dir = geo_path.parent
-
-    usd_path = usd_dir / usd_file_name
-
-    return str(usd_path)
+        create_temp_hou_stage(file_path)

--- a/src/usd_indie_pipe/_houdini.py
+++ b/src/usd_indie_pipe/_houdini.py
@@ -58,7 +58,7 @@ def construct_usd_file_path(geo_path: Path, separate_usd_folder: bool = True) ->
     If separate_usd_folder is True, usd files will be put into usd subfolder.
     """
     clean_base = geo_path.name.split(".")[0]
-    usd_file_name = clean_base + ".usda"
+    usd_file_name = clean_base + ".usd"
 
     if separate_usd_folder:
         usd_dir = geo_path.parent / "usd"

--- a/src/usd_indie_pipe/_houdini.py
+++ b/src/usd_indie_pipe/_houdini.py
@@ -47,7 +47,7 @@ def create_temp_hou_stage(file_path):
 
         # Execute save usd file
         usd_rop.parm("execute").pressButton()
-        print(f"Converted USD: {str(usd_file)}")
+        print(f"CONVERTED USD: {str(usd_file)}")
 
         return usd_file
 
@@ -71,18 +71,13 @@ def construct_usd_file_path(geo_path: Path, separate_usd_folder: bool = True) ->
 
 def run_geo_to_usd_conversion(asset_lib_path: str, lib_name=None, tex_folder_path=None) -> None:
     """
-    Runs geometry-to-USD conversion for all assets found in the given asset library path.
+    Runs geometry-to-usd conversion for all assets found in the given asset library path.
 
     If a library name is provided, the texture folder will be automatically resolved based on
     the expected folder structure of the specified library (currently supports Kitbash and Megascans).
 
     If no library name is provided, you can optionally specify a texture folder directly.
     If neither is provided, the tool will default to using the same folder as the geometry file.
-
-    Parameters:
-        asset_lib_path (str): Path to the asset library folder containing geometry files.
-        lib_name (str, optional): Optional library tag ("Kitbash" or "Megascans") to auto-resolve texture paths.
-        tex_folder_path (str, optional): Optional path to a folder containing texture files.
     """
     conv_data = _utils.create_assets_dictionary(asset_lib_path, lib_name, tex_folder_path)
     for file_path, tex_folder in conv_data.items():

--- a/src/usd_indie_pipe/_houdini.py
+++ b/src/usd_indie_pipe/_houdini.py
@@ -71,15 +71,21 @@ def construct_usd_file_path(geo_path: Path, separate_usd_folder: bool = True) ->
 
 def run_geo_to_usd_conversion(asset_lib_path: str, lib_name=None, tex_folder_path=None) -> None:
     """
-     Runs geometry-to-usd conversion using a list of input geometry files provided in a json file.
+    Runs geometry-to-USD conversion for all assets found in the given asset library path.
+
+    If a library name is provided, the texture folder will be automatically resolved based on
+    the expected folder structure of the specified library (currently supports Kitbash and Megascans).
+
+    If no library name is provided, you can optionally specify a texture folder directly.
+    If neither is provided, the tool will default to using the same folder as the geometry file.
 
     Parameters:
-        conversion_data (str): Path to a json file containing a list of geometry file paths (e.g., .bgeo.sc, .obj).
-        tex_folder_path (str): Path to a folder containing tex files.
+        asset_lib_path (str): Path to the asset library folder containing geometry files.
+        lib_name (str, optional): Optional library tag ("Kitbash" or "Megascans") to auto-resolve texture paths.
+        tex_folder_path (str, optional): Optional path to a folder containing texture files.
     """
     conv_data = _utils.create_assets_dictionary(asset_lib_path, lib_name, tex_folder_path)
     for file_path, tex_folder in conv_data.items():
         file_path = Path(file_path)
         usd_file = create_temp_hou_stage(file_path)
-
         _usd.run_material_assignment(usd_file, str(tex_folder))

--- a/src/usd_indie_pipe/_houdini.py
+++ b/src/usd_indie_pipe/_houdini.py
@@ -1,7 +1,9 @@
-import json
 from pathlib import Path
-import _usd
+
 import hou
+
+import _usd
+import _utils
 
 
 def create_temp_hou_stage(file_path):
@@ -13,6 +15,7 @@ def create_temp_hou_stage(file_path):
         raise FileNotFoundError(f"Could not find geometry file: {file_path}")
     else:
         # create Sop read
+        print(f"ASSET NAME: {asset_name}")
         sop_create = hou.node("/stage").createNode("sopcreate", asset_name)
         sop_create.parm("enable_partitionattribs").set(True)
         sop_create.parm("partitionattribs").set("path")
@@ -66,7 +69,7 @@ def construct_usd_file_path(geo_path: Path, separate_usd_folder: bool = True) ->
     return str(usd_path)
 
 
-def run_geo_to_usd_conversion(conversion_data: str, tex_folder_path: str) -> None:
+def run_geo_to_usd_conversion(asset_lib_path: str, lib_name=None, tex_folder_path=None) -> None:
     """
      Runs geometry-to-usd conversion using a list of input geometry files provided in a json file.
 
@@ -74,9 +77,9 @@ def run_geo_to_usd_conversion(conversion_data: str, tex_folder_path: str) -> Non
         conversion_data (str): Path to a json file containing a list of geometry file paths (e.g., .bgeo.sc, .obj).
         tex_folder_path (str): Path to a folder containing tex files.
     """
-    with open(conversion_data, "r") as r:
-        conv_data = json.load(r)
-    for file_path in conv_data:
+    conv_data = _utils.create_assets_dictionary(asset_lib_path, lib_name, tex_folder_path)
+    for file_path, tex_folder in conv_data.items():
         file_path = Path(file_path)
         usd_file = create_temp_hou_stage(file_path)
-        _usd.run_material_assignment(usd_file, tex_folder_path)
+
+        _usd.run_material_assignment(usd_file, str(tex_folder))

--- a/src/usd_indie_pipe/_usd.py
+++ b/src/usd_indie_pipe/_usd.py
@@ -85,7 +85,7 @@ def populate_textures(stage: Usd.Stage, mat: Usd.Prim, parms_mapping: dict) -> N
     displacement_shader.CreateIdAttr("ND_displacement_float")
     displacement_shader_output = displacement_shader.CreateOutput("out", Sdf.ValueTypeNames.Token)
 
-    # if textures replacing default values with textures
+    # if textures -> replacing default values with textures
     for parm_name, tex_path in parms_mapping.items():
         uv_tex = UsdShade.Shader.Define(stage, f"{mat_path}/mtlx_{parm_name}")
         uv_tex.CreateIdAttr("ND_UsdUVTexture")
@@ -98,5 +98,4 @@ def populate_textures(stage: Usd.Stage, mat: Usd.Prim, parms_mapping: dict) -> N
     mat.CreateOutput("mtlx:surface", Sdf.ValueTypeNames.Token).ConnectToSource(surface_shader_output)
     mat.CreateOutput("mtlx:displacement", Sdf.ValueTypeNames.Token).ConnectToSource(displacement_shader_output)
     mat.CreateSurfaceOutput().ConnectToSource(surface_shader_output)
-    print(f"MAPPING: {parms_mapping}")
     return print(f"Material populated: {mat_path}")

--- a/src/usd_indie_pipe/_usd.py
+++ b/src/usd_indie_pipe/_usd.py
@@ -1,0 +1,102 @@
+from pxr import Usd, UsdShade, Kind, Sdf
+
+from usd_indie_pipe.texture_resolve import TextureResolve
+
+
+def create_material_prim(usd_stage: str, materials: list, tex_folder_path: str) -> Usd.Prim:
+    stage = Usd.Stage.Open(usd_stage)
+    subsets = get_subcomponents(stage)
+
+    for prim in stage.Traverse():
+        if not prim.IsValid() or not prim.IsDefined():
+            continue
+        if Usd.ModelAPI(prim).GetKind() == Kind.Tokens.component:
+            for mat in materials:
+                mat_lib_path = prim.GetPath().AppendPath("materials")
+                mat_lib_ = stage.DefinePrim(mat_lib_path, "Scope")
+                mat_path = mat_lib_path.AppendPath(mat)
+
+                mat_prim = UsdShade.Material.Define(stage, mat_path)
+
+                for sub_prim in subsets:
+
+                    tex_name = sub_prim.GetName()
+
+                    if mat == tex_name:
+                        UsdShade.MaterialBindingAPI.Apply(sub_prim).Bind(mat_prim)
+                        attr = sub_prim.GetAttribute("familyName")
+                        attr.Set("materialBind")
+
+                        mapping = solve_texture(usd_stage, tex_name, tex_folder_path)
+
+                        populate_textures(stage, mat_prim, mapping)
+
+            stage.GetRootLayer().Save()
+
+
+def get_subcomponents(stage: Usd.Stage) -> list:
+    subsets = []
+    for prim in stage.Traverse():
+        if not prim.IsValid() or not prim.IsDefined():
+            continue
+        if prim.GetTypeName() == "GeomSubset":
+            subsets.append(prim)
+    return subsets
+
+
+def solve_texture(usd_file: str, namespace: str, tex_folder_path: str) -> dict:
+    tex_resolve = TextureResolve(usd_file, namespace, tex_folder_path)
+    tex_resolve.geometry_file = usd_file
+    tex_resolve.namespace = namespace
+    tex_resolve.tex_folder_path = tex_folder_path
+    mapping = dict(tex_resolve.parse_texture())
+    return mapping
+
+
+def run_material_assignment(usd_file: str, tex_folder_path: str) -> None:
+    stage = Usd.Stage.Open(usd_file)
+    subc = get_subcomponents(stage)
+    mat_lis = [s.GetName() for s in subc]
+    create_material_prim(usd_file, mat_lis, tex_folder_path)
+
+
+def populate_textures(stage: Usd.Stage, mat: Usd.Prim, parms_mapping: dict) -> None:
+    mat_path = mat.GetPath()
+    surface_shader = UsdShade.Shader.Define(stage, f"{mat_path}/mtlxstandard_surface")  # define shader surface
+    surface_shader.CreateIdAttr("ND_standard_surface_surfaceshader")
+
+    # default_values:
+    surface_shader.CreateInput("base", Sdf.ValueTypeNames.Float).Set(1.0)
+    surface_shader.CreateInput("coat", Sdf.ValueTypeNames.Float).Set(0.0)
+    surface_shader.CreateInput("coat_roughness", Sdf.ValueTypeNames.Float).Set(0.1)
+    surface_shader.CreateInput("emission", Sdf.ValueTypeNames.Float).Set(0.0)
+    surface_shader.CreateInput("emission_color", Sdf.ValueTypeNames.Float3).Set((1.0, 1.0, 1.0))
+    surface_shader.CreateInput("metalness", Sdf.ValueTypeNames.Float).Set(0.0)
+    surface_shader.CreateInput("specular", Sdf.ValueTypeNames.Float).Set(1.0)
+    surface_shader.CreateInput("specular_color", Sdf.ValueTypeNames.Float3).Set((1.0, 1.0, 1.0))
+    surface_shader.CreateInput("specular_IOR", Sdf.ValueTypeNames.Float).Set(1.5)
+    surface_shader.CreateInput("specular_roughness", Sdf.ValueTypeNames.Float).Set(0.2)
+    surface_shader.CreateInput("transmission", Sdf.ValueTypeNames.Float).Set(0.0)
+    surface_shader.CreateOutput("out", Sdf.ValueTypeNames.Token)
+    surface_shader_output = surface_shader.CreateOutput("out", Sdf.ValueTypeNames.Token)
+
+    # add displacement
+    displacement_shader = UsdShade.Shader.Define(stage, f"{mat_path}/mtlxdisplacement")
+    displacement_shader.CreateIdAttr("ND_displacement_float")
+    displacement_shader_output = displacement_shader.CreateOutput("out", Sdf.ValueTypeNames.Token)
+
+    # if textures replacing default values with textures
+    for parm_name, tex_path in parms_mapping.items():
+        uv_tex = UsdShade.Shader.Define(stage, f"{mat_path}/mtlx_{parm_name}")
+        uv_tex.CreateIdAttr("ND_UsdUVTexture")
+        uv_tex.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath(str(tex_path)))
+        uv_tex.CreateOutput("rgb", Sdf.ValueTypeNames.Float3)
+        rgb_output = uv_tex.CreateOutput("rgb", Sdf.ValueTypeNames.Float3)
+        surface_shader.CreateInput("base_color", Sdf.ValueTypeNames.Float3).ConnectToSource(rgb_output)
+        # Material outputs connecting to shader outputs
+
+    mat.CreateOutput("mtlx:surface", Sdf.ValueTypeNames.Token).ConnectToSource(surface_shader_output)
+    mat.CreateOutput("mtlx:displacement", Sdf.ValueTypeNames.Token).ConnectToSource(displacement_shader_output)
+    mat.CreateSurfaceOutput().ConnectToSource(surface_shader_output)
+    print(f"MAPPING: {parms_mapping}")
+    return print(f"Material populated: {mat_path}")

--- a/src/usd_indie_pipe/_usd.py
+++ b/src/usd_indie_pipe/_usd.py
@@ -78,10 +78,8 @@ def solve_texture(usd_file: str, namespace: str, tex_folder_path: str) -> dict:
 def run_material_assignment(usd_file: str, tex_folder_path: str) -> None:
     """
     Runs material creation and assignment for a USD stage.
-
     This function gathers all geometry subsets, determines material names,
     and calls the material creation and binding pipeline.
-
     """
     stage = Usd.Stage.Open(usd_file)
     subc = get_subsets(stage)
@@ -91,11 +89,9 @@ def run_material_assignment(usd_file: str, tex_folder_path: str) -> None:
 
 def populate_mtlx(stage: Usd.Stage, mat: Usd.Prim, parms_mapping: dict) -> None:
     """
-    Populates a MaterialX surface and displacement shader with default parameters and textures.
-
+    Populates a materialX surface and displacement shader with default parameters and textures.
     For each texture entry in the parameter mapping, a UsdUVTexture is created and
     connected to the corresponding input on either the surface or displacement shader.
-
     """
     mat_path = mat.GetPath()
     surface_shader = UsdShade.Shader.Define(stage, f"{mat_path}/mtlxstandard_surface")  # define shader surface
@@ -134,9 +130,9 @@ def populate_mtlx(stage: Usd.Stage, mat: Usd.Prim, parms_mapping: dict) -> None:
         else:
             surface_shader.CreateInput(parm_name, Sdf.ValueTypeNames.Float3).ConnectToSource(rgb_output)
         print(f"CREATED TEXTURE {parm_name} : {tex_path}")
-        # Material outputs connecting to shader outputs
 
+        # Material outputs connecting to shader outputs
     mat.CreateOutput("mtlx:surface", Sdf.ValueTypeNames.Token).ConnectToSource(surface_shader_output)
     mat.CreateOutput("mtlx:displacement", Sdf.ValueTypeNames.Token).ConnectToSource(displacement_shader_output)
     mat.CreateSurfaceOutput().ConnectToSource(surface_shader_output)
-    return print(f"Material populated: {mat_path}")
+    return print(f"MATERIAL POPULATED: {mat_path}")

--- a/src/usd_indie_pipe/_utils.py
+++ b/src/usd_indie_pipe/_utils.py
@@ -1,0 +1,5 @@
+import re
+
+
+def flatten_input_data(data_str: str) -> str:
+    return re.sub(r'[^a-zA-Z0-9]', '', data_str).lower()

--- a/src/usd_indie_pipe/_utils.py
+++ b/src/usd_indie_pipe/_utils.py
@@ -5,7 +5,7 @@ from pathlib import Path
 def flatten_input_data(data_str: str) -> str:
     """
     Removes all non-alphanumeric characters and converts the string to lowercase.
-    Used for matching texture and primitives.
+    Used for matching texture and primitives in usd stage.
     """
     return re.sub(r'[^a-zA-Z0-9]', '', data_str).lower()
 
@@ -13,9 +13,7 @@ def flatten_input_data(data_str: str) -> str:
 def create_assets_dictionary(asset_lib_path: str, lib_name=None, tex_folder_path=None) -> dict:
     """
     Builds a dictionary mapping geometry files to their corresponding texture folders.
-
     The mapping strategy varies depending on whether a known library type or an explicit texture folder path is provided.
-
     Supported cases:
     - Libraries: "Kitbash", "Megascans"
     - Matching a folder of assets to a separate texture folder
@@ -54,7 +52,7 @@ def create_assets_dictionary(asset_lib_path: str, lib_name=None, tex_folder_path
 
         elif lib_name == "Megascans":
             for asset in lib_path.iterdir():
-                geo_folder = asset  # asset is already a Path
+                geo_folder = asset
                 if geo_folder.is_dir():
                     for geo_file in geo_folder.iterdir():
                         if geo_file.is_file() and any(

--- a/src/usd_indie_pipe/_utils.py
+++ b/src/usd_indie_pipe/_utils.py
@@ -1,5 +1,53 @@
 import re
+from pathlib import Path
 
 
 def flatten_input_data(data_str: str) -> str:
     return re.sub(r'[^a-zA-Z0-9]', '', data_str).lower()
+
+
+def create_assets_dictionary(asset_lib_path: str, lib_name=None, tex_folder_path=None) -> dict:
+    geo_tex_mapping = {}
+    file_formats = ["fbx", "bgeo.sc", "obj"]
+    lib_path = Path(asset_lib_path)
+    if lib_name and tex_folder_path is None:
+        if lib_name == "Kitbash":
+            geo_folder = lib_path / "geo"
+            tex_folder = lib_path / "KB3DTextures"
+            if geo_folder.is_dir() and tex_folder.is_dir():
+
+                resolution_folder = next(
+                    (f for f in tex_folder.iterdir() if f.is_dir() and re.match(r'^\d+k$', f.name)),
+                    None
+                )
+                tex_folder = tex_folder / resolution_folder
+                for geo_file in geo_folder.iterdir():
+                    if any(geo_file.name.endswith(f".{ext}") for ext in file_formats):
+                        geo_tex_mapping[geo_file] = tex_folder
+                        print(f"{geo_file} -> {tex_folder}")
+
+        elif lib_name == "Megascans":
+            for asset in lib_path.iterdir():
+                geo_folder = lib_path / asset
+                if geo_folder.is_dir():
+                    for geo_file in geo_folder.iterdir():
+                        if geo_file.name.endswith(".fbx"):
+                            geo_tex_mapping[geo_file] = geo_folder
+
+
+    elif tex_folder_path and lib_name is None:
+        for asset in lib_path.iterdir():
+            if asset.is_dir():
+                geo_tex_mapping[asset] = tex_folder_path
+
+    elif lib_name is None and tex_folder_path is None:
+
+        for asset in lib_path.iterdir():
+            for format in file_formats:
+                if asset.name.endswith(format):
+                    geo_tex_mapping[asset] = lib_path
+
+    else:
+        raise ValueError(f"Not enough data: ")
+
+    return geo_tex_mapping

--- a/src/usd_indie_pipe/_utils.py
+++ b/src/usd_indie_pipe/_utils.py
@@ -3,51 +3,84 @@ from pathlib import Path
 
 
 def flatten_input_data(data_str: str) -> str:
+    """
+    Removes all non-alphanumeric characters and converts the string to lowercase.
+    Used for matching texture and primitives.
+    """
     return re.sub(r'[^a-zA-Z0-9]', '', data_str).lower()
 
 
 def create_assets_dictionary(asset_lib_path: str, lib_name=None, tex_folder_path=None) -> dict:
+    """
+    Builds a dictionary mapping geometry files to their corresponding texture folders.
+
+    The mapping strategy varies depending on whether a known library type or an explicit texture folder path is provided.
+
+    Supported cases:
+    - Libraries: "Kitbash", "Megascans"
+    - Matching a folder of assets to a separate texture folder
+    - If neither `lib_name` nor `tex_folder_path` is provided, the geometry file’s folder is used as the texture folder by default.
+    """
+
     geo_tex_mapping = {}
     file_formats = ["fbx", "bgeo.sc", "obj"]
     lib_path = Path(asset_lib_path)
+
+    if not lib_path.is_dir():
+        raise ValueError(f"Invalid Asset Library Path: {asset_lib_path}")
+
+    if lib_name and tex_folder_path:
+        raise ValueError("Specify either lib_name or tex_folder_path, not both.")
+
     if lib_name and tex_folder_path is None:
         if lib_name == "Kitbash":
             geo_folder = lib_path / "geo"
             tex_folder = lib_path / "KB3DTextures"
-            if geo_folder.is_dir() and tex_folder.is_dir():
 
+            if geo_folder.is_dir() and tex_folder.is_dir():
                 resolution_folder = next(
                     (f for f in tex_folder.iterdir() if f.is_dir() and re.match(r'^\d+k$', f.name)),
                     None
                 )
+                if resolution_folder is None:
+                    raise FileNotFoundError(f"No resolution folder like '2k', '4k' found in {tex_folder}")
+
                 tex_folder = tex_folder / resolution_folder
+
                 for geo_file in geo_folder.iterdir():
-                    if any(geo_file.name.endswith(f".{ext}") for ext in file_formats):
+                    if geo_file.is_file() and any(geo_file.name.lower().endswith(f".{ext}") for ext in file_formats):
                         geo_tex_mapping[geo_file] = tex_folder
                         print(f"{geo_file} -> {tex_folder}")
 
         elif lib_name == "Megascans":
             for asset in lib_path.iterdir():
-                geo_folder = lib_path / asset
+                geo_folder = asset  # asset is already a Path
                 if geo_folder.is_dir():
                     for geo_file in geo_folder.iterdir():
-                        if geo_file.name.endswith(".fbx"):
+                        if geo_file.is_file() and any(
+                                geo_file.name.lower().endswith(f".{ext}") for ext in file_formats):
                             geo_tex_mapping[geo_file] = geo_folder
-
+        else:
+            raise ValueError(f"Unsupported library name: {lib_name}, currently supported: 'Kitbash', 'Megascans'")
 
     elif tex_folder_path and lib_name is None:
-        for asset in lib_path.iterdir():
-            if asset.is_dir():
-                geo_tex_mapping[asset] = tex_folder_path
+        tex_folder_path = Path(tex_folder_path)
+        if tex_folder_path.is_dir():
+            for asset in lib_path.iterdir():
+                if asset.is_file() and any(asset.name.lower().endswith(f".{ext}") for ext in file_formats):
+                    geo_tex_mapping[asset] = tex_folder_path
+        else:
+            raise ValueError(f"Texture folder {tex_folder_path} not found")
 
     elif lib_name is None and tex_folder_path is None:
-
         for asset in lib_path.iterdir():
-            for format in file_formats:
-                if asset.name.endswith(format):
-                    geo_tex_mapping[asset] = lib_path
+            if asset.is_file() and any(asset.name.lower().endswith(f".{ext}") for ext in file_formats):
+                geo_tex_mapping[asset] = lib_path
 
     else:
-        raise ValueError(f"Not enough data: ")
+        raise ValueError("Invalid argument combination")
+
+    if not geo_tex_mapping:
+        raise ValueError("No valid geometry-texture mappings found.")
 
     return geo_tex_mapping

--- a/src/usd_indie_pipe/convert_to_usd.json
+++ b/src/usd_indie_pipe/convert_to_usd.json
@@ -1,5 +1,0 @@
-[
-    "/Users/kmaev/Documents/hou_dev/cat_hou/assets/kb3d_ironforge/geo/KB3D_IRF_PropGloves_A.bgeo.sc",
-    "/Users/kmaev/Documents/hou_dev/cat_hou/assets/kb3d_ironforge/geo/KB3D_IRF_PropLever_A.bgeo.sc",
-    "/Users/kmaev/Documents/hou_dev/cat_hou/assets/kb3d_ironforge/geo/KB3D_IRF_BldgSmBorderHouse.bgeo.sc"
-]

--- a/src/usd_indie_pipe/convert_to_usd.json
+++ b/src/usd_indie_pipe/convert_to_usd.json
@@ -1,0 +1,5 @@
+[
+    "/Users/kmaev/Documents/hou_dev/cat_hou/assets/kb3d_ironforge/geo/KB3D_IRF_PropGloves_A.bgeo.sc",
+    "/Users/kmaev/Documents/hou_dev/cat_hou/assets/kb3d_ironforge/geo/KB3D_IRF_PropLever_A.bgeo.sc",
+    "/Users/kmaev/Documents/hou_dev/cat_hou/assets/kb3d_ironforge/geo/KB3D_IRF_BldgSmBorderHouse.bgeo.sc"
+]

--- a/src/usd_indie_pipe/convert_to_usd.py
+++ b/src/usd_indie_pipe/convert_to_usd.py
@@ -1,3 +1,33 @@
+"""
+Before running the command, make sure USD is installed in your environment.
+
+Run the following command: the Hython executable, followed by the path to the convert_usd.py file,
+then add the --asset-lib-path argument, and optionally: --lib-name and --textures-folder-path.
+
+Example usage (Kitbash):
+/Applications/Houdini/Houdini20.5.613/Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython \
+  /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.py \
+  --asset-lib-path /Users/kmaev/Documents/hou_dev/assets/kb3d_ironforge_test_lib/ \
+  --lib-name Kitbash
+
+Example usage (Megascans):
+/Applications/Houdini/Houdini20.5.613/Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython \
+  /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.py \
+  --asset-lib-path /Users/kmaev/Documents/hou_dev/assets/megascans \
+  --lib-name Megascans
+
+Example usage: Match geometry and texture folders independently of the library:
+/Applications/Houdini/Houdini20.5.613/Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython \
+  /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.py \
+  --asset-lib-path /Users/kmaev/Documents/hou_dev/assets/kb3d_ironforge_test_lib/geo \
+  --textures-folder-path /Users/kmaev/Documents/hou_dev/assets/kb3d_ironforge_test_lib/KB3DTextures/4k
+
+Example usage: No texture path or texture library provided
+(by default, the tool uses the file's folder as the texture folder):
+/Applications/Houdini/Houdini20.5.613/Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython \
+  /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.py \
+  --asset-lib-path /Users/kmaev/Documents/hou_dev/assets/megascans/japanese_gravestone_ucmmfjgfa_mid
+"""
 import argparse
 import importlib
 import sys
@@ -27,25 +57,7 @@ def main(args: list[str] | None = None):
         namespace.textures_folder_path,
     )
 
-
 if __name__ == "__main__":
     main()
 
-"""
-Before running the command, make sure USD is installed in your environment.
-Run the following command: the Hython executable, followed by the path to the convert_usd.py file,
-then add the --template_path argument, and optionally: --lib-name and --textures-folder_path.
 
-Example usage Kitbash
-/Applications/Houdini/Houdini20.5.613/Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython \
-  /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.py \
-  --asset-lib-path /Users/kmaev/Documents/hou_dev/assets/kb3d_ironforge_test_lib/ \
-  --lib-name Kitbash
-  
-Example usage Megascans:
-/Applications/Houdini/Houdini20.5.613/Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython \
-  /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.py \
-  --asset-lib-path /Users/kmaev/Documents/hou_dev/assets/megascans \
-  --lib-name Megascans
-
-"""

--- a/src/usd_indie_pipe/convert_to_usd.py
+++ b/src/usd_indie_pipe/convert_to_usd.py
@@ -1,0 +1,37 @@
+import argparse
+import importlib
+import sys
+from pathlib import Path
+
+_THIS = Path(__file__)
+
+TEMPLATE_PATH = _THIS.parent.joinpath("convert_to_usd.json")
+
+SRC_ROOT = _THIS.parent.parent
+module_path = str(SRC_ROOT)
+
+if module_path not in sys.path:
+    sys.path.append(module_path)
+
+    _hou_ip = importlib.import_module('usd_indie_pipe._houdini')
+
+
+def main(args: list[str] | None = None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--template-path", required=True)
+
+    namespace = parser.parse_args(args)
+
+    _hou_ip.run_geo_to_usd_conversion(
+        namespace.template_path,
+    )
+
+
+if __name__ == "__main__":
+    main()
+
+"""
+Run the following command: Hython executable, path to the convert_usd.py file + --template_path + json file template
+/Applications/Houdini/Houdini20.5.410/Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython \
+  /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.py \
+  --template-path /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.json"""

--- a/src/usd_indie_pipe/convert_to_usd.py
+++ b/src/usd_indie_pipe/convert_to_usd.py
@@ -6,6 +6,7 @@ from pathlib import Path
 _THIS = Path(__file__)
 
 TEMPLATE_PATH = _THIS.parent.joinpath("convert_to_usd.json")
+DEFAULT_TEXTURES_FOLDER_PATH = _THIS.parent.joinpath("textures")
 
 SRC_ROOT = _THIS.parent.parent
 module_path = str(SRC_ROOT)
@@ -19,11 +20,12 @@ if module_path not in sys.path:
 def main(args: list[str] | None = None):
     parser = argparse.ArgumentParser()
     parser.add_argument("--template-path", required=True)
-
+    parser.add_argument("--textures-folder-path", default=DEFAULT_TEXTURES_FOLDER_PATH,required=True)
     namespace = parser.parse_args(args)
 
     _hou_ip.run_geo_to_usd_conversion(
         namespace.template_path,
+        namespace.textures_folder_path,
     )
 
 
@@ -34,4 +36,5 @@ if __name__ == "__main__":
 Run the following command: Hython executable, path to the convert_usd.py file + --template_path + json file template
 /Applications/Houdini/Houdini20.5.613/Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython \
   /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.py \
-  --template-path /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.json"""
+  --template-path /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.json \
+   --textures-folder-path /Users/kmaev/Documents/hou_dev/cat_hou/assets/kb3d_ironforge/KB3DTextures/4k"""

--- a/src/usd_indie_pipe/convert_to_usd.py
+++ b/src/usd_indie_pipe/convert_to_usd.py
@@ -5,9 +5,6 @@ from pathlib import Path
 
 _THIS = Path(__file__)
 
-TEMPLATE_PATH = _THIS.parent.joinpath("convert_to_usd.json")
-DEFAULT_TEXTURES_FOLDER_PATH = _THIS.parent.joinpath("textures")
-
 SRC_ROOT = _THIS.parent.parent
 module_path = str(SRC_ROOT)
 
@@ -19,12 +16,14 @@ if module_path not in sys.path:
 
 def main(args: list[str] | None = None):
     parser = argparse.ArgumentParser()
-    parser.add_argument("--template-path", required=True)
-    parser.add_argument("--textures-folder-path", default=DEFAULT_TEXTURES_FOLDER_PATH,required=True)
+    parser.add_argument("--asset-lib-path", required=True, default=None)
+    parser.add_argument("--lib-name", required=False, default=None)
+    parser.add_argument("--textures-folder-path", required=False, default=None)
     namespace = parser.parse_args(args)
 
     _hou_ip.run_geo_to_usd_conversion(
-        namespace.template_path,
+        namespace.asset_lib_path,
+        namespace.lib_name,
         namespace.textures_folder_path,
     )
 
@@ -33,8 +32,20 @@ if __name__ == "__main__":
     main()
 
 """
-Run the following command: Hython executable, path to the convert_usd.py file + --template_path + json file template
+Before running the command, make sure USD is installed in your environment.
+Run the following command: the Hython executable, followed by the path to the convert_usd.py file,
+then add the --template_path argument, and optionally: --lib-name and --textures-folder_path.
+
+Example usage Kitbash
 /Applications/Houdini/Houdini20.5.613/Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython \
   /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.py \
-  --template-path /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.json \
-   --textures-folder-path /Users/kmaev/Documents/hou_dev/cat_hou/assets/kb3d_ironforge/KB3DTextures/4k"""
+  --asset-lib-path /Users/kmaev/Documents/hou_dev/assets/kb3d_ironforge_test_lib/ \
+  --lib-name Kitbash
+  
+Example usage Megascans:
+/Applications/Houdini/Houdini20.5.613/Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython \
+  /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.py \
+  --asset-lib-path /Users/kmaev/Documents/hou_dev/assets/megascans \
+  --lib-name Megascans
+
+"""

--- a/src/usd_indie_pipe/convert_to_usd.py
+++ b/src/usd_indie_pipe/convert_to_usd.py
@@ -32,6 +32,6 @@ if __name__ == "__main__":
 
 """
 Run the following command: Hython executable, path to the convert_usd.py file + --template_path + json file template
-/Applications/Houdini/Houdini20.5.410/Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython \
+/Applications/Houdini/Houdini20.5.613/Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython \
   /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.py \
   --template-path /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.json"""

--- a/src/usd_indie_pipe/convert_to_usd.py
+++ b/src/usd_indie_pipe/convert_to_usd.py
@@ -19,8 +19,8 @@ Example usage (Megascans):
 Example usage: Match geometry and texture folders independently of the library:
 /Applications/Houdini/Houdini20.5.613/Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython \
   /Users/kmaev/Documents/hou_dev/usd_indie_pipe/src/usd_indie_pipe/convert_to_usd.py \
-  --asset-lib-path /Users/kmaev/Documents/hou_dev/assets/kb3d_ironforge_test_lib/geo \
-  --textures-folder-path /Users/kmaev/Documents/hou_dev/assets/kb3d_ironforge_test_lib/KB3DTextures/4k
+  --asset-lib-path /Users/kmaev/Documents/hou_dev/assets/kb3d_match_by_folders/geo \
+  --textures-folder-path /Users/kmaev/Documents/hou_dev/assets/kb3d_match_by_folders/KB3DTextures/4k
 
 Example usage: No texture path or texture library provided
 (by default, the tool uses the file's folder as the texture folder):

--- a/src/usd_indie_pipe/texture_resolve.py
+++ b/src/usd_indie_pipe/texture_resolve.py
@@ -12,7 +12,10 @@ class TextureResolve:
 
     tex_conversion: dict[str, str] = field(default_factory=lambda: {
         "base_color": "basecolor",
-        "specular": "specular"
+        "specular": "specular",
+        "emission": "emissive",
+        "displacement": "height",
+        "specular_roughness": "roughness"
     })
     mapping: dict[str, pathlib.Path] = field(default_factory=dict)
 
@@ -22,6 +25,7 @@ class TextureResolve:
 
         tex_folder_abs_path = pathlib.Path(self.tex_folder_path)
         for file in tex_folder_abs_path.iterdir():
+
             file_edit = flatten_input_data(str(file.stem))
             for mlx_text, source_tex in self.tex_conversion.items():
                 texture_edit = flatten_input_data(source_tex)

--- a/src/usd_indie_pipe/texture_resolve.py
+++ b/src/usd_indie_pipe/texture_resolve.py
@@ -14,8 +14,8 @@ class TextureResolve:
         "specular": "specular",
         "normal": "normal"
     })
-    mapping = {}
-    name_space = ""
+    mapping: dict[str, pathlib.Path] = field(default_factory=dict)
+    name_space: str = ""
 
 
 

--- a/src/usd_indie_pipe/texture_resolve.py
+++ b/src/usd_indie_pipe/texture_resolve.py
@@ -1,39 +1,30 @@
-import os
-import re
 import pathlib
-import _utils
 from dataclasses import dataclass, field
+
+from usd_indie_pipe._utils import flatten_input_data
 
 
 @dataclass
 class TextureResolve:
     geometry_file: str
-    tex_folder_relative_path: str = "./"
+    tex_folder_path: str = ""
+    namespace: str = ""
+
     tex_conversion: dict[str, str] = field(default_factory=lambda: {
         "base_color": "basecolor",
-        "specular": "specular",
-        "normal": "normal"
+        "specular": "specular"
     })
     mapping: dict[str, pathlib.Path] = field(default_factory=dict)
-    name_space: str = ""
-
-
-
-    def get_folder_abs_path(self)->pathlib.Path:
-        return pathlib.Path(os.path.dirname(self.geometry_file))
 
     def parse_texture(self):
-        name_space_edit = _utils.flatten_input_data(self.name_space)
-        folder_path = self.get_folder_abs_path()
-        tex_abs_path = pathlib.Path(os.path.normpath(os.path.join(str(folder_path), self.tex_folder_relative_path)))
+        # we remove the first few characters just because we use asset name as a namespace, and sometimes it comes with prefixes
+        name_space_edit = flatten_input_data(self.namespace)[5:]
 
-        for file in tex_abs_path.iterdir():
-            file_edit = _utils.flatten_input_data(str(file))
+        tex_folder_abs_path = pathlib.Path(self.tex_folder_path)
+        for file in tex_folder_abs_path.iterdir():
+            file_edit = flatten_input_data(str(file.stem))
             for mlx_text, source_tex in self.tex_conversion.items():
-                texture_edit = _utils.flatten_input_data(source_tex)
+                texture_edit = flatten_input_data(source_tex)
                 if texture_edit in file_edit and name_space_edit in file_edit:
                     self.mapping[mlx_text] = file
         return self.mapping
-
-
-

--- a/src/usd_indie_pipe/texture_resolve.py
+++ b/src/usd_indie_pipe/texture_resolve.py
@@ -7,7 +7,7 @@ from usd_indie_pipe._utils import flatten_input_data
 @dataclass
 class TextureResolve:
     geometry_file: str
-    tex_folder_path: str = ""
+    tex_folder_path: str = None
     namespace: str = ""
 
     tex_conversion: dict[str, str] = field(default_factory=lambda: {
@@ -19,7 +19,7 @@ class TextureResolve:
     })
     mapping: dict[str, pathlib.Path] = field(default_factory=dict)
 
-    def parse_texture(self):
+    def parse_texture(self) -> dict:
         # we remove the first few characters just because we use asset name as a namespace, and sometimes it comes with prefixes
         name_space_edit = flatten_input_data(self.namespace)[5:]
 

--- a/src/usd_indie_pipe/texture_resolve.py
+++ b/src/usd_indie_pipe/texture_resolve.py
@@ -1,0 +1,39 @@
+import os
+import re
+import pathlib
+import _utils
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TextureResolve:
+    geometry_file: str
+    tex_folder_relative_path: str = "./"
+    tex_conversion: dict[str, str] = field(default_factory=lambda: {
+        "base_color": "basecolor",
+        "specular": "specular",
+        "normal": "normal"
+    })
+    mapping = {}
+    name_space = ""
+
+
+
+    def get_folder_abs_path(self)->pathlib.Path:
+        return pathlib.Path(os.path.dirname(self.geometry_file))
+
+    def parse_texture(self):
+        name_space_edit = _utils.flatten_input_data(self.name_space)
+        folder_path = self.get_folder_abs_path()
+        tex_abs_path = pathlib.Path(os.path.normpath(os.path.join(str(folder_path), self.tex_folder_relative_path)))
+
+        for file in tex_abs_path.iterdir():
+            file_edit = _utils.flatten_input_data(str(file))
+            for mlx_text, source_tex in self.tex_conversion.items():
+                texture_edit = _utils.flatten_input_data(source_tex)
+                if texture_edit in file_edit and name_space_edit in file_edit:
+                    self.mapping[mlx_text] = file
+        return self.mapping
+
+
+


### PR DESCRIPTION
Add CLI tool  to convert geometry files (e.g., .geo, .fbx) into .usd format.
It parses textures based on a library name (if supported, e.g., Kitbash, Megascans) or from a specified texture folder, creates MaterialX shaders populated with the corresponding textures, and automatically binds materials to USD primitives